### PR TITLE
Remove named statements from tokio-postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: sfackler/actions/rustup@master
         with:
-          version: 1.65.0
+          version: 1.67.0
       - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
       - run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: sfackler/actions/rustup@master
-      - run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
+        with:
+          version: 1.65.0
+      - run: echo "::set-output name=version::$(rustc --version)"
         id: rust-version
       - run: rustup target add wasm32-unknown-unknown
       - uses: actions/cache@v3

--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -72,6 +72,7 @@ impl Header {
 }
 
 /// An enum representing Postgres backend messages.
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Message {
     AuthenticationCleartextPassword,
@@ -333,6 +334,7 @@ impl Read for Buffer {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationMd5PasswordBody {
     salt: [u8; 4],
 }
@@ -344,6 +346,7 @@ impl AuthenticationMd5PasswordBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationGssContinueBody(Bytes);
 
 impl AuthenticationGssContinueBody {
@@ -353,6 +356,7 @@ impl AuthenticationGssContinueBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslBody(Bytes);
 
 impl AuthenticationSaslBody {
@@ -362,6 +366,7 @@ impl AuthenticationSaslBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SaslMechanisms<'a>(&'a [u8]);
 
 impl<'a> FallibleIterator for SaslMechanisms<'a> {
@@ -387,6 +392,7 @@ impl<'a> FallibleIterator for SaslMechanisms<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslContinueBody(Bytes);
 
 impl AuthenticationSaslContinueBody {
@@ -396,6 +402,7 @@ impl AuthenticationSaslContinueBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct AuthenticationSaslFinalBody(Bytes);
 
 impl AuthenticationSaslFinalBody {
@@ -405,6 +412,7 @@ impl AuthenticationSaslFinalBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct BackendKeyDataBody {
     process_id: i32,
     secret_key: i32,
@@ -422,6 +430,7 @@ impl BackendKeyDataBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CommandCompleteBody {
     tag: Bytes,
 }
@@ -433,6 +442,7 @@ impl CommandCompleteBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyDataBody {
     storage: Bytes,
 }
@@ -449,6 +459,7 @@ impl CopyDataBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyInResponseBody {
     format: u8,
     len: u16,
@@ -470,6 +481,7 @@ impl CopyInResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ColumnFormats<'a> {
     buf: &'a [u8],
     remaining: u16,
@@ -503,6 +515,7 @@ impl<'a> FallibleIterator for ColumnFormats<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct CopyOutResponseBody {
     format: u8,
     len: u16,
@@ -524,7 +537,7 @@ impl CopyOutResponseBody {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DataRowBody {
     storage: Bytes,
     len: u16,
@@ -599,6 +612,7 @@ impl<'a> FallibleIterator for DataRowRanges<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ErrorResponseBody {
     storage: Bytes,
 }
@@ -657,6 +671,7 @@ impl<'a> ErrorField<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct NoticeResponseBody {
     storage: Bytes,
 }
@@ -668,6 +683,7 @@ impl NoticeResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct NotificationResponseBody {
     process_id: i32,
     channel: Bytes,
@@ -691,6 +707,7 @@ impl NotificationResponseBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ParameterDescriptionBody {
     storage: Bytes,
     len: u16,
@@ -706,6 +723,7 @@ impl ParameterDescriptionBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Parameters<'a> {
     buf: &'a [u8],
     remaining: u16,
@@ -739,6 +757,7 @@ impl<'a> FallibleIterator for Parameters<'a> {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ParameterStatusBody {
     name: Bytes,
     value: Bytes,
@@ -756,6 +775,7 @@ impl ParameterStatusBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct ReadyForQueryBody {
     status: u8,
 }
@@ -767,6 +787,7 @@ impl ReadyForQueryBody {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct RowDescriptionBody {
     storage: Bytes,
     len: u16,

--- a/postgres-types/src/chrono_04.rs
+++ b/postgres-types/src/chrono_04.rs
@@ -40,7 +40,7 @@ impl ToSql for NaiveDateTime {
 impl<'a> FromSql<'a> for DateTime<Utc> {
     fn from_sql(type_: &Type, raw: &[u8]) -> Result<DateTime<Utc>, Box<dyn Error + Sync + Send>> {
         let naive = NaiveDateTime::from_sql(type_, raw)?;
-        Ok(DateTime::from_utc(naive, Utc))
+        Ok(DateTime::from_naive_utc_and_offset(naive, Utc))
     }
 
     accepts!(TIMESTAMPTZ);

--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -442,6 +442,22 @@ impl WrongType {
     }
 }
 
+/// An error indicating that a as_text conversion was attempted on a binary
+/// result.
+#[derive(Debug)]
+pub struct WrongFormat {}
+
+impl Error for WrongFormat {}
+
+impl fmt::Display for WrongFormat {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            fmt,
+            "cannot read column as text while it is in binary format"
+        )
+    }
+}
+
 /// A trait for types that can be created from a Postgres value.
 ///
 /// # Types
@@ -893,7 +909,7 @@ pub trait ToSql: fmt::Debug {
 /// Supported Postgres message format types
 ///
 /// Using Text format in a message assumes a Postgres `SERVER_ENCODING` of `UTF8`
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Format {
     /// Text format (UTF-8)
     Text,

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -59,7 +59,7 @@ postgres-types = { version = "0.2.5", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.8.5"
-whoami = "1.4.1"
+whoami = "1.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.5", features = ["all"] }

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -31,7 +31,7 @@ where
 
     match responses.next().await? {
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(Portal::new(client, name, statement))

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -231,7 +231,11 @@ impl Client {
         query: &str,
         parameter_types: &[Type],
     ) -> Result<Statement, Error> {
-        prepare::prepare(&self.inner, query, parameter_types).await
+        prepare::prepare(&self.inner, query, parameter_types, false).await
+    }
+
+    pub(crate) async fn prepare_unnamed(&self, query: &str) -> Result<Statement, Error> {
+        prepare::prepare(&self.inner, query, &[], true).await
     }
 
     /// Executes a statement, returning a vector of the resulting rows.

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -231,11 +231,11 @@ impl Client {
         query: &str,
         parameter_types: &[Type],
     ) -> Result<Statement, Error> {
-        prepare::prepare(&self.inner, query, parameter_types, false).await
+        prepare::prepare(&self.inner, query, parameter_types).await
     }
 
     pub(crate) async fn prepare_unnamed(&self, query: &str) -> Result<Statement, Error> {
-        prepare::prepare(&self.inner, query, &[], true).await
+        prepare::prepare(&self.inner, query, &[]).await
     }
 
     /// Executes a statement, returning a vector of the resulting rows.

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -4,8 +4,10 @@ use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
 #[cfg(feature = "runtime")]
 use crate::keepalive::KeepaliveConfig;
+use crate::prepare::get_type;
 use crate::query::RowStream;
 use crate::simple_query::SimpleQueryStream;
+use crate::statement::Column;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
@@ -16,7 +18,7 @@ use crate::{
     copy_in, copy_out, prepare, query, simple_query, slice_iter, CancelToken, CopyInSink, Error,
     Row, SimpleQueryMessage, Statement, ToStatement, Transaction, TransactionBuilder,
 };
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use fallible_iterator::FallibleIterator;
 use futures_channel::mpsc;
 use futures_util::{future, pin_mut, ready, StreamExt, TryStreamExt};
@@ -366,6 +368,87 @@ impl Client {
     {
         let statement = statement.__convert().into_statement(self).await?;
         query::query(&self.inner, statement, params).await
+    }
+
+    /// Pass text directly to the Postgres backend to allow it to sort out typing itself and
+    /// to save a roundtrip
+    pub async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    where
+        S: AsRef<str>,
+        I: IntoIterator<Item = S>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let params = params.into_iter();
+        let params_len = params.len();
+
+        let buf = self.inner.with_buf(|buf| {
+            // Parse, anonymous portal
+            frontend::parse("", query.as_ref(), std::iter::empty(), buf).map_err(Error::encode)?;
+            // Bind, pass params as text, retrieve as binary
+            match frontend::bind(
+                "",                 // empty string selects the unnamed portal
+                "",                 // empty string selects the unnamed prepared statement
+                std::iter::empty(), // all parameters use the default format (text)
+                params,
+                |param, buf| {
+                    buf.put_slice(param.as_ref().as_bytes());
+                    Ok(postgres_protocol::IsNull::No)
+                },
+                Some(0), // all text
+                buf,
+            ) {
+                Ok(()) => Ok(()),
+                Err(frontend::BindError::Conversion(e)) => Err(Error::to_sql(e, 0)),
+                Err(frontend::BindError::Serialization(e)) => Err(Error::encode(e)),
+            }?;
+
+            // Describe portal to typecast results
+            frontend::describe(b'P', "", buf).map_err(Error::encode)?;
+            // Execute
+            frontend::execute("", 0, buf).map_err(Error::encode)?;
+            // Sync
+            frontend::sync(buf);
+
+            Ok(buf.split().freeze())
+        })?;
+
+        let mut responses = self
+            .inner
+            .send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
+
+        // now read the responses
+
+        match responses.next().await? {
+            Message::ParseComplete => {}
+            _ => return Err(Error::unexpected_message()),
+        }
+        match responses.next().await? {
+            Message::BindComplete => {}
+            _ => return Err(Error::unexpected_message()),
+        }
+        let row_description = match responses.next().await? {
+            Message::RowDescription(body) => Some(body),
+            Message::NoData => None,
+            _ => return Err(Error::unexpected_message()),
+        };
+
+        // construct statement object
+
+        let parameters = vec![Type::UNKNOWN; params_len];
+
+        let mut columns = vec![];
+        if let Some(row_description) = row_description {
+            let mut it = row_description.fields();
+            while let Some(field) = it.next().map_err(Error::parse)? {
+                let type_ = get_type(&self.inner, field.type_oid()).await?;
+                let column = Column::new(field.name().to_string(), type_);
+                columns.push(column);
+            }
+        }
+
+        let statement = Statement::new_text(&self.inner, "".to_owned(), parameters, columns);
+
+        Ok(RowStream::new(statement, responses))
     }
 
     /// Executes a statement, returning the number of rows modified.

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -443,8 +443,10 @@ impl Client {
         if let Some(row_description) = row_description {
             let mut it = row_description.fields();
             while let Some(field) = it.next().map_err(Error::parse)? {
+                // NB: for some types that function may send a query to the server. At least in
+                // raw text mode we don't need that info and can skip this.
                 let type_ = get_type(&self.inner, field.type_oid()).await?;
-                let column = Column::new(field.name().to_string(), type_);
+                let column = Column::new(field.name().to_string(), type_, field);
                 columns.push(column);
             }
         }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -207,6 +207,8 @@ pub struct Config {
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) load_balance_hosts: LoadBalanceHosts,
+    pub(crate) replication_mode: Option<ReplicationMode>,
+    pub(crate) max_backend_message_size: Option<usize>,
 }
 
 impl Default for Config {
@@ -240,6 +242,8 @@ impl Config {
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
             load_balance_hosts: LoadBalanceHosts::Disable,
+            replication_mode: None,
+            max_backend_message_size: None,
         }
     }
 
@@ -520,6 +524,17 @@ impl Config {
         self.load_balance_hosts
     }
 
+    /// Set limit for backend messages size.
+    pub fn max_backend_message_size(&mut self, max_backend_message_size: usize) -> &mut Config {
+        self.max_backend_message_size = Some(max_backend_message_size);
+        self
+    }
+
+    /// Get limit for backend messages size.
+    pub fn get_max_backend_message_size(&self) -> Option<usize> {
+        self.max_backend_message_size
+    }
+
     fn param(&mut self, key: &str, value: &str) -> Result<(), Error> {
         match key {
             "user" => {
@@ -654,6 +669,14 @@ impl Config {
                     }
                 };
                 self.load_balance_hosts(load_balance_hosts);
+            }
+            "max_backend_message_size" => {
+                let limit = value.parse::<usize>().map_err(|_| {
+                    Error::config_parse(Box::new(InvalidValue("max_backend_message_size")))
+                })?;
+                if limit > 0 {
+                    self.max_backend_message_size(limit);
+                }
             }
             key => {
                 return Err(Error::config_parse(Box::new(UnknownOption(

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -207,7 +207,6 @@ pub struct Config {
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) load_balance_hosts: LoadBalanceHosts,
-    pub(crate) replication_mode: Option<ReplicationMode>,
     pub(crate) max_backend_message_size: Option<usize>,
 }
 
@@ -242,7 +241,6 @@ impl Config {
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
             load_balance_hosts: LoadBalanceHosts::Disable,
-            replication_mode: None,
             max_backend_message_size: None,
         }
     }

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -195,7 +195,7 @@ where
                     }
                 }
                 Some(_) => {}
-                None => return Err(Error::unexpected_message()),
+                None => return Err(Error::closed()),
             }
         }
     }

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -92,7 +92,12 @@ where
     let stream = connect_tls(stream, config.ssl_mode, tls, has_hostname).await?;
 
     let mut stream = StartupStream {
-        inner: Framed::new(stream, PostgresCodec),
+        inner: Framed::new(
+            stream,
+            PostgresCodec {
+                max_message_size: config.max_backend_message_size,
+            },
+        ),
         buf: BackendMessages::empty(),
         delayed: VecDeque::new(),
     };

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -195,14 +195,14 @@ where
             ))
         }
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     }
 
     match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationOk) => Ok(()),
         Some(Message::ErrorResponse(body)) => Err(Error::db(body)),
-        Some(_) => Err(Error::unexpected_message()),
+        Some(m) => Err(Error::unexpected_message(m)),
         None => Err(Error::closed()),
     }
 }
@@ -296,7 +296,7 @@ where
     let body = match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationSaslContinue(body)) => body,
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     };
 
@@ -314,7 +314,7 @@ where
     let body = match stream.try_next().await.map_err(Error::io)? {
         Some(Message::AuthenticationSaslFinal(body)) => body,
         Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-        Some(_) => return Err(Error::unexpected_message()),
+        Some(m) => return Err(Error::unexpected_message(m)),
         None => return Err(Error::closed()),
     };
 
@@ -353,7 +353,7 @@ where
             }
             Some(Message::ReadyForQuery(_)) => return Ok((process_id, secret_key, parameters)),
             Some(Message::ErrorResponse(body)) => return Err(Error::db(body)),
-            Some(_) => return Err(Error::unexpected_message()),
+            Some(m) => return Err(Error::unexpected_message(m)),
             None => return Err(Error::closed()),
         }
     }

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -139,7 +139,8 @@ where
                 Some(response) => response,
                 None => match messages.next().map_err(Error::parse)? {
                     Some(Message::ErrorResponse(error)) => return Err(Error::db(error)),
-                    _ => return Err(Error::unexpected_message()),
+                    Some(m) => return Err(Error::unexpected_message(m)),
+                    None => return Err(Error::closed()),
                 },
             };
 

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -192,7 +192,7 @@ pub async fn copy_in<T>(client: &InnerClient, statement: Statement) -> Result<Co
 where
     T: Buf + 'static + Send,
 {
-    debug!("executing copy in statement {}", statement.name());
+    debug!("executing copy in statement");
 
     let buf = query::encode(client, &statement, slice_iter(&[]))?;
 
@@ -206,12 +206,10 @@ where
         .map_err(|_| Error::closed())?;
 
     match responses.next().await? {
-        Message::ParseComplete => {
-            match responses.next().await? {
-                Message::BindComplete => {}
-                m => return Err(Error::unexpected_message(m)),
-            }
-        }
+        Message::ParseComplete => match responses.next().await? {
+            Message::BindComplete => {}
+            m => return Err(Error::unexpected_message(m)),
+        },
         Message::BindComplete => {}
         m => return Err(Error::unexpected_message(m)),
     }

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -26,13 +26,17 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
     match responses.next().await? {
+        Message::ParseComplete => match responses.next().await? {
+            Message::BindComplete => {}
+            m => return Err(Error::unexpected_message(m)),
+        },
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     match responses.next().await? {
         Message::CopyOutResponse(_) => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(responses)
@@ -56,7 +60,7 @@ impl Stream for CopyOutStream {
         match ready!(this.responses.poll_next(cx)?) {
             Message::CopyData(body) => Poll::Ready(Some(Ok(body.into_bytes()))),
             Message::CopyDone => Poll::Ready(None),
-            _ => Poll::Ready(Some(Err(Error::unexpected_message()))),
+            m => Poll::Ready(Some(Err(Error::unexpected_message(m)))),
         }
     }
 }

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<CopyOutStream, Error> {
-    debug!("executing copy out statement {}", statement.name());
+    debug!("executing copy out statement");
 
     let buf = query::encode(client, &statement, slice_iter(&[]))?;
     let responses = start(client, buf).await?;

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -56,6 +56,13 @@ pub trait GenericClient: private::Sealed {
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator;
 
+    /// Like `Client::query_raw_txt`.
+    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    where
+        S: AsRef<str> + Sync + Send,
+        I: IntoIterator<Item = Option<S>> + Sync + Send,
+        I::IntoIter: ExactSizeIterator + Sync + Send;
+
     /// Like `Client::prepare`.
     async fn prepare(&self, query: &str) -> Result<Statement, Error>;
 
@@ -134,6 +141,15 @@ impl GenericClient for Client {
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await
+    }
+
+    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    where
+        S: AsRef<str> + Sync + Send,
+        I: IntoIterator<Item = Option<S>> + Sync + Send,
+        I::IntoIter: ExactSizeIterator + Sync + Send,
+    {
+        self.query_raw_txt(query, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
@@ -220,6 +236,15 @@ impl GenericClient for Transaction<'_> {
         I::IntoIter: ExactSizeIterator,
     {
         self.query_raw(statement, params).await
+    }
+
+    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    where
+        S: AsRef<str> + Sync + Send,
+        I: IntoIterator<Item = Option<S>> + Sync + Send,
+        I::IntoIter: ExactSizeIterator + Sync + Send,
+    {
+        self.query_raw_txt(query, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -57,8 +57,13 @@ pub trait GenericClient: private::Sealed {
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query_raw_txt`.
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(
+        &self,
+        statement: &T,
+        params: I,
+    ) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send;
@@ -143,13 +148,14 @@ impl GenericClient for Client {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,
     {
-        self.query_raw_txt(query, params).await
+        self.query_raw_txt(statement, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {
@@ -238,13 +244,14 @@ impl GenericClient for Transaction<'_> {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
+        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,
     {
-        self.query_raw_txt(query, params).await
+        self.query_raw_txt(statement, params).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -126,7 +126,7 @@ fn encode(client: &InnerClient, name: &str, query: &str, types: &[Type]) -> Resu
     })
 }
 
-async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
+pub async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
     if let Some(type_) = Type::from_oid(oid) {
         return Ok(type_);
     }

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -95,7 +95,7 @@ pub async fn prepare(
         let mut it = row_description.fields();
         while let Some(field) = it.next().map_err(Error::parse)? {
             let type_ = get_type(client, field.type_oid()).await?;
-            let column = Column::new(field.name().to_string(), type_);
+            let column = Column::new(field.name().to_string(), type_, field);
             columns.push(column);
         }
     }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -1,17 +1,15 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::prepare::get_type;
 use crate::types::{BorrowToSql, IsNull};
-use crate::{Column, Error, Portal, Row, Statement};
+use crate::{Error, Portal, Row, Statement};
 use bytes::{BufMut, Bytes, BytesMut};
-use fallible_iterator::FallibleIterator;
 use futures_util::{ready, Stream};
 use log::{debug, log_enabled, Level};
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::{CommandCompleteBody, Message};
 use postgres_protocol::message::frontend;
-use postgres_types::Type;
+use postgres_types::Format;
 use std::fmt;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
@@ -58,30 +56,29 @@ where
         responses,
         rows_affected: None,
         command_tag: None,
+        status: None,
+        output_format: Format::Binary,
         _p: PhantomPinned,
     })
 }
 
 pub async fn query_txt<S, I>(
     client: &Arc<InnerClient>,
-    query: S,
+    statement: Statement,
     params: I,
 ) -> Result<RowStream, Error>
 where
-    S: AsRef<str> + Sync + Send,
+    S: AsRef<str>,
     I: IntoIterator<Item = Option<S>>,
     I::IntoIter: ExactSizeIterator,
 {
     let params = params.into_iter();
-    let params_len = params.len();
 
     let buf = client.with_buf(|buf| {
-        // Parse, anonymous portal
-        frontend::parse("", query.as_ref(), std::iter::empty(), buf).map_err(Error::encode)?;
         // Bind, pass params as text, retrieve as binary
         match frontend::bind(
             "",                 // empty string selects the unnamed portal
-            "",                 // empty string selects the unnamed prepared statement
+            statement.name(),   // named prepared statement
             std::iter::empty(), // all parameters use the default format (text)
             params,
             |param, buf| match param {
@@ -99,8 +96,6 @@ where
             Err(frontend::BindError::Serialization(e)) => Err(Error::encode(e)),
         }?;
 
-        // Describe portal to typecast results
-        frontend::describe(b'P', "", buf).map_err(Error::encode)?;
         // Execute
         frontend::execute("", 0, buf).map_err(Error::encode)?;
         // Sync
@@ -109,43 +104,17 @@ where
         Ok(buf.split().freeze())
     })?;
 
-    let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
-
     // now read the responses
-
-    match responses.next().await? {
-        Message::ParseComplete => {}
-        _ => return Err(Error::unexpected_message()),
-    }
-    match responses.next().await? {
-        Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
-    }
-    let row_description = match responses.next().await? {
-        Message::RowDescription(body) => Some(body),
-        Message::NoData => None,
-        _ => return Err(Error::unexpected_message()),
-    };
-
-    // construct statement object
-
-    let parameters = vec![Type::UNKNOWN; params_len];
-
-    let mut columns = vec![];
-    if let Some(row_description) = row_description {
-        let mut it = row_description.fields();
-        while let Some(field) = it.next().map_err(Error::parse)? {
-            // NB: for some types that function may send a query to the server. At least in
-            // raw text mode we don't need that info and can skip this.
-            let type_ = get_type(client, field.type_oid()).await?;
-            let column = Column::new(field.name().to_string(), type_, field);
-            columns.push(column);
-        }
-    }
-
-    let statement = Statement::new_text(client, "".to_owned(), parameters, columns);
-
-    Ok(RowStream::new(statement, responses))
+    let responses = start(client, buf).await?;
+    Ok(RowStream {
+        statement,
+        responses,
+        command_tag: None,
+        status: None,
+        output_format: Format::Text,
+        _p: PhantomPinned,
+        rows_affected: None,
+    })
 }
 
 pub async fn query_portal(
@@ -166,6 +135,8 @@ pub async fn query_portal(
         responses,
         rows_affected: None,
         command_tag: None,
+        status: None,
+        output_format: Format::Binary,
         _p: PhantomPinned,
     })
 }
@@ -301,20 +272,10 @@ pin_project! {
         responses: Responses,
         rows_affected: Option<u64>,
         command_tag: Option<String>,
+        output_format: Format,
+        status: Option<u8>,
         #[pin]
         _p: PhantomPinned,
-    }
-}
-
-impl RowStream {
-    /// Creates a new `RowStream`.
-    pub fn new(statement: Statement, responses: Responses) -> Self {
-        RowStream {
-            statement,
-            responses,
-            command_tag: None,
-            _p: PhantomPinned,
-        }
     }
 }
 
@@ -326,7 +287,11 @@ impl Stream for RowStream {
         loop {
             match ready!(this.responses.poll_next(cx)?) {
                 Message::DataRow(body) => {
-                    return Poll::Ready(Some(Ok(Row::new(this.statement.clone(), body)?)))
+                    return Poll::Ready(Some(Ok(Row::new(
+                        this.statement.clone(),
+                        body,
+                        *this.output_format,
+                    )?)))
                 }
                 Message::CommandComplete(body) => {
                     *this.rows_affected = Some(extract_row_affected(&body)?);
@@ -336,7 +301,10 @@ impl Stream for RowStream {
                     }
                 }
                 Message::EmptyQueryResponse | Message::PortalSuspended => {}
-                Message::ReadyForQuery(_) => return Poll::Ready(None),
+                Message::ReadyForQuery(status) => {
+                    *this.status = Some(status.status());
+                    return Poll::Ready(None);
+                }
                 _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
             }
         }
@@ -356,5 +324,12 @@ impl RowStream {
     /// This is only available after the stream has been exhausted.
     pub fn command_tag(&self) -> Option<String> {
         self.command_tag.clone()
+    }
+
+    /// Returns if the connection is ready for querying, with the status of the connection.
+    ///
+    /// This might be available only after the stream has been exhausted.
+    pub fn ready_status(&self) -> Option<u8> {
+        self.status
     }
 }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -186,7 +186,7 @@ where
             }
             Message::EmptyQueryResponse => rows = 0,
             Message::ReadyForQuery(_) => return Ok(rows),
-            _ => return Err(Error::unexpected_message()),
+            m => return Err(Error::unexpected_message(m)),
         }
     }
 }
@@ -195,8 +195,12 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
     match responses.next().await? {
+        Message::ParseComplete => match responses.next().await? {
+            Message::BindComplete => {}
+            m => return Err(Error::unexpected_message(m)),
+        },
         Message::BindComplete => {}
-        _ => return Err(Error::unexpected_message()),
+        m => return Err(Error::unexpected_message(m)),
     }
 
     Ok(responses)
@@ -209,6 +213,9 @@ where
     I::IntoIter: ExactSizeIterator,
 {
     client.with_buf(|buf| {
+        if let Some(query) = statement.query() {
+            frontend::parse("", query, [], buf).unwrap();
+        }
         encode_bind(statement, params, "", buf)?;
         frontend::execute("", 0, buf).map_err(Error::encode)?;
         frontend::sync(buf);
@@ -305,7 +312,7 @@ impl Stream for RowStream {
                     *this.status = Some(status.status());
                     return Poll::Ready(None);
                 }
-                _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                m => return Poll::Ready(Some(Err(Error::unexpected_message(m)))),
             }
         }
     }

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -98,6 +98,7 @@ where
 /// A row of data returned from the database by a query.
 pub struct Row {
     statement: Statement,
+    output_format: Format,
     body: DataRowBody,
     ranges: Vec<Option<Range<usize>>>,
 }
@@ -111,12 +112,17 @@ impl fmt::Debug for Row {
 }
 
 impl Row {
-    pub(crate) fn new(statement: Statement, body: DataRowBody) -> Result<Row, Error> {
+    pub(crate) fn new(
+        statement: Statement,
+        body: DataRowBody,
+        output_format: Format,
+    ) -> Result<Row, Error> {
         let ranges = body.ranges().collect().map_err(Error::parse)?;
         Ok(Row {
             statement,
             body,
             ranges,
+            output_format,
         })
     }
 
@@ -193,7 +199,7 @@ impl Row {
     ///
     /// Useful when using query_raw_txt() which sets text transfer mode
     pub fn as_text(&self, idx: usize) -> Result<Option<&str>, Error> {
-        if self.statement.output_format() == Format::Text {
+        if self.output_format == Format::Text {
             match self.col_buffer(idx) {
                 Some(raw) => {
                     FromSql::from_sql(&Type::TEXT, raw).map_err(|e| Error::from_sql(e, idx))

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -58,7 +58,7 @@ pub async fn batch_execute(client: &InnerClient, query: &str) -> Result<(), Erro
             | Message::EmptyQueryResponse
             | Message::RowDescription(_)
             | Message::DataRow(_) => {}
-            _ => return Err(Error::unexpected_message()),
+            m => return Err(Error::unexpected_message(m)),
         }
     }
 }
@@ -107,12 +107,12 @@ impl Stream for SimpleQueryStream {
                 Message::DataRow(body) => {
                     let row = match &this.columns {
                         Some(columns) => SimpleQueryRow::new(columns.clone(), body)?,
-                        None => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                        None => return Poll::Ready(Some(Err(Error::closed()))),
                     };
                     return Poll::Ready(Some(Ok(SimpleQueryMessage::Row(row))));
                 }
                 Message::ReadyForQuery(_) => return Poll::Ready(None),
-                _ => return Poll::Ready(Some(Err(Error::unexpected_message()))),
+                m => return Poll::Ready(Some(Err(Error::unexpected_message(m)))),
             }
         }
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -11,22 +11,31 @@ use std::{
     sync::{Arc, Weak},
 };
 
-struct StatementInner {
-    client: Weak<InnerClient>,
-    name: String,
-    params: Vec<Type>,
-    columns: Vec<Column>,
+enum StatementInner {
+    Unnamed {
+        query: String,
+        params: Vec<Type>,
+        columns: Vec<Column>,
+    },
+    Named {
+        client: Weak<InnerClient>,
+        name: String,
+        params: Vec<Type>,
+        columns: Vec<Column>,
+    },
 }
 
 impl Drop for StatementInner {
     fn drop(&mut self) {
-        if let Some(client) = self.client.upgrade() {
-            let buf = client.with_buf(|buf| {
-                frontend::close(b'S', &self.name, buf).unwrap();
-                frontend::sync(buf);
-                buf.split().freeze()
-            });
-            let _ = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+        if let StatementInner::Named { client, name, .. } = self {
+            if let Some(client) = client.upgrade() {
+                let buf = client.with_buf(|buf| {
+                    frontend::close(b'S', name, buf).unwrap();
+                    frontend::sync(buf);
+                    buf.split().freeze()
+                });
+                let _ = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+            }
         }
     }
 }
@@ -38,13 +47,13 @@ impl Drop for StatementInner {
 pub struct Statement(Arc<StatementInner>);
 
 impl Statement {
-    pub(crate) fn new(
+    pub(crate) fn named(
         inner: &Arc<InnerClient>,
         name: String,
         params: Vec<Type>,
         columns: Vec<Column>,
     ) -> Statement {
-        Statement(Arc::new(StatementInner {
+        Statement(Arc::new(StatementInner::Named {
             client: Arc::downgrade(inner),
             name,
             params,
@@ -52,18 +61,42 @@ impl Statement {
         }))
     }
 
+    pub(crate) fn unnamed(query: String, params: Vec<Type>, columns: Vec<Column>) -> Self {
+        Statement(Arc::new(StatementInner::Unnamed {
+            query,
+            params,
+            columns,
+        }))
+    }
+
     pub(crate) fn name(&self) -> &str {
-        &self.0.name
+        match &*self.0 {
+            StatementInner::Unnamed { .. } => "",
+            StatementInner::Named { name, .. } => name,
+        }
+    }
+
+    pub(crate) fn query(&self) -> Option<&str> {
+        match &*self.0 {
+            StatementInner::Unnamed { query, .. } => Some(query),
+            StatementInner::Named { .. } => None,
+        }
     }
 
     /// Returns the expected types of the statement's parameters.
     pub fn params(&self) -> &[Type] {
-        &self.0.params
+        match &*self.0 {
+            StatementInner::Unnamed { params, .. } => params,
+            StatementInner::Named { params, .. } => params,
+        }
     }
 
     /// Returns information about the columns returned when the statement is queried.
     pub fn columns(&self) -> &[Column] {
-        &self.0.columns
+        match &*self.0 {
+            StatementInner::Unnamed { columns, .. } => columns,
+            StatementInner::Named { columns, .. } => columns,
+        }
     }
 }
 

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -6,7 +6,6 @@ use postgres_protocol::{
     message::{backend::Field, frontend},
     Oid,
 };
-use postgres_types::Format;
 use std::{
     fmt,
     sync::{Arc, Weak},
@@ -17,7 +16,6 @@ struct StatementInner {
     name: String,
     params: Vec<Type>,
     columns: Vec<Column>,
-    output_format: Format,
 }
 
 impl Drop for StatementInner {
@@ -51,22 +49,6 @@ impl Statement {
             name,
             params,
             columns,
-            output_format: Format::Binary,
-        }))
-    }
-
-    pub(crate) fn new_text(
-        inner: &Arc<InnerClient>,
-        name: String,
-        params: Vec<Type>,
-        columns: Vec<Column>,
-    ) -> Statement {
-        Statement(Arc::new(StatementInner {
-            client: Arc::downgrade(inner),
-            name,
-            params,
-            columns,
-            output_format: Format::Text,
         }))
     }
 
@@ -82,11 +64,6 @@ impl Statement {
     /// Returns information about the columns returned when the statement is queried.
     pub fn columns(&self) -> &[Column] {
         &self.0.columns
-    }
-
-    /// Returns output format for the statement.
-    pub fn output_format(&self) -> Format {
-        self.0.output_format
     }
 }
 

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -2,7 +2,10 @@ use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::types::Type;
-use postgres_protocol::message::frontend;
+use postgres_protocol::{
+    message::{backend::Field, frontend},
+    Oid,
+};
 use postgres_types::Format;
 use std::{
     fmt,
@@ -91,11 +94,30 @@ impl Statement {
 pub struct Column {
     name: String,
     type_: Type,
+
+    // raw fields from RowDescription
+    table_oid: Oid,
+    column_id: i16,
+    format: i16,
+
+    // that better be stored in self.type_, but that is more radical refactoring
+    type_oid: Oid,
+    type_size: i16,
+    type_modifier: i32,
 }
 
 impl Column {
-    pub(crate) fn new(name: String, type_: Type) -> Column {
-        Column { name, type_ }
+    pub(crate) fn new(name: String, type_: Type, raw_field: Field<'_>) -> Column {
+        Column {
+            name,
+            type_,
+            table_oid: raw_field.table_oid(),
+            column_id: raw_field.column_id(),
+            format: raw_field.format(),
+            type_oid: raw_field.type_oid(),
+            type_size: raw_field.type_size(),
+            type_modifier: raw_field.type_modifier(),
+        }
     }
 
     /// Returns the name of the column.
@@ -106,6 +128,36 @@ impl Column {
     /// Returns the type of the column.
     pub fn type_(&self) -> &Type {
         &self.type_
+    }
+
+    /// Returns the table OID of the column.
+    pub fn table_oid(&self) -> Oid {
+        self.table_oid
+    }
+
+    /// Returns the column ID of the column.
+    pub fn column_id(&self) -> i16 {
+        self.column_id
+    }
+
+    /// Returns the format of the column.
+    pub fn format(&self) -> i16 {
+        self.format
+    }
+
+    /// Returns the type OID of the column.
+    pub fn type_oid(&self) -> Oid {
+        self.type_oid
+    }
+
+    /// Returns the type size of the column.
+    pub fn type_size(&self) -> i16 {
+        self.type_size
+    }
+
+    /// Returns the type modifier of the column.
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
     }
 }
 

--- a/tokio-postgres/src/to_statement.rs
+++ b/tokio-postgres/src/to_statement.rs
@@ -15,7 +15,7 @@ mod private {
         pub async fn into_statement(self, client: &Client) -> Result<Statement, Error> {
             match self {
                 ToStatementType::Statement(s) => Ok(s.clone()),
-                ToStatementType::Query(s) => client.prepare(s).await,
+                ToStatementType::Query(s) => client.prepare_unnamed(s).await,
             }
         }
     }

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -149,6 +149,16 @@ impl<'a> Transaction<'a> {
         self.client.query_raw(statement, params).await
     }
 
+    /// Like `Client::query_raw_txt`.
+    pub async fn query_raw_txt<S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    where
+        S: AsRef<str> + Sync + Send,
+        I: IntoIterator<Item = Option<S>>,
+        I::IntoIter: ExactSizeIterator + Sync + Send,
+    {
+        self.client.query_raw_txt(query, params).await
+    }
+
     /// Like `Client::execute`.
     pub async fn execute<T>(
         &self,

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -150,13 +150,14 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_raw_txt`.
-    pub async fn query_raw_txt<S, I>(&self, query: S, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw_txt<T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
     where
-        S: AsRef<str> + Sync + Send,
+        T: ?Sized + ToStatement,
+        S: AsRef<str>,
         I: IntoIterator<Item = Option<S>>,
-        I::IntoIter: ExactSizeIterator + Sync + Send,
+        I::IntoIter: ExactSizeIterator,
     {
-        self.client.query_raw_txt(query, params).await
+        self.client.query_raw_txt(statement, params).await
     }
 
     /// Like `Client::execute`.

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -312,7 +312,7 @@ async fn query_raw_txt_nulls() {
 async fn limit_max_backend_message_size() {
     let client = connect("user=postgres max_backend_message_size=10000").await;
     let small: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("SELECT REPEAT('a', 20)", [])
+        .query_raw_txt("SELECT REPEAT('a', 20)", [] as [Option<&str>; 0])
         .await
         .unwrap()
         .try_collect()
@@ -323,7 +323,7 @@ async fn limit_max_backend_message_size() {
     assert_eq!(small[0].as_text(0).unwrap().unwrap().len(), 20);
 
     let large: Result<Vec<tokio_postgres::Row>, Error> = client
-        .query_raw_txt("SELECT REPEAT('a', 2000000)", [])
+        .query_raw_txt("SELECT REPEAT('a', 2000000)", [] as [Option<&str>; 0])
         .await
         .unwrap()
         .try_collect()
@@ -337,7 +337,7 @@ async fn command_tag() {
     let client = connect("user=postgres").await;
 
     let row_stream = client
-        .query_raw_txt("select unnest('{1,2,3}'::int[]);", [])
+        .query_raw_txt("select unnest('{1,2,3}'::int[]);", [] as [Option<&str>; 0])
         .await
         .unwrap();
 
@@ -352,11 +352,39 @@ async fn command_tag() {
 }
 
 #[tokio::test]
+async fn ready_for_query() {
+    let client = connect("user=postgres").await;
+
+    let row_stream = client
+        .query_raw_txt("START TRANSACTION", [] as [Option<&str>; 0])
+        .await
+        .unwrap();
+
+    pin_mut!(row_stream);
+    while row_stream.next().await.is_none() {}
+
+    assert_eq!(row_stream.ready_status(), Some(b'T'));
+
+    let row_stream = client
+        .query_raw_txt("ROLLBACK", [] as [Option<&str>; 0])
+        .await
+        .unwrap();
+
+    pin_mut!(row_stream);
+    while row_stream.next().await.is_none() {}
+
+    assert_eq!(row_stream.ready_status(), Some(b'I'));
+}
+
+#[tokio::test]
 async fn column_extras() {
     let client = connect("user=postgres").await;
 
     let rows: Vec<tokio_postgres::Row> = client
-        .query_raw_txt("select relacl, relname from pg_class limit 1", [])
+        .query_raw_txt(
+            "select relacl, relname from pg_class limit 1",
+            [] as [Option<&str>; 0],
+        )
         .await
         .unwrap()
         .try_collect()

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -250,6 +250,78 @@ async fn custom_array() {
 }
 
 #[tokio::test]
+async fn query_raw_txt() {
+    let client = connect("user=postgres").await;
+
+    let rows: Vec<tokio_postgres::Row> = client
+        .query_raw_txt("SELECT 55 * $1", ["42"])
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    let res: i32 = rows[0].as_text(0).unwrap().unwrap().parse::<i32>().unwrap();
+    assert_eq!(res, 55 * 42);
+
+    let rows: Vec<tokio_postgres::Row> = client
+        .query_raw_txt("SELECT $1", ["42"])
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, &str>(0), "42");
+    assert!(rows[0].body_len() > 0);
+}
+
+#[tokio::test]
+async fn limit_max_backend_message_size() {
+    let client = connect("user=postgres max_backend_message_size=10000").await;
+    let small: Vec<tokio_postgres::Row> = client
+        .query_raw_txt("SELECT REPEAT('a', 20)", [])
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(small.len(), 1);
+    assert_eq!(small[0].as_text(0).unwrap().unwrap().len(), 20);
+
+    let large: Result<Vec<tokio_postgres::Row>, Error> = client
+        .query_raw_txt("SELECT REPEAT('a', 2000000)", [])
+        .await
+        .unwrap()
+        .try_collect()
+        .await;
+
+    assert!(large.is_err());
+}
+
+#[tokio::test]
+async fn command_tag() {
+    let client = connect("user=postgres").await;
+
+    let row_stream = client
+        .query_raw_txt("select unnest('{1,2,3}'::int[]);", [])
+        .await
+        .unwrap();
+
+    pin_mut!(row_stream);
+
+    let mut rows: Vec<tokio_postgres::Row> = Vec::new();
+    while let Some(row) = row_stream.next().await {
+        rows.push(row.unwrap());
+    }
+
+    assert_eq!(row_stream.command_tag(), Some("SELECT 3".to_string()));
+}
+
+#[tokio::test]
 async fn custom_composite() {
     let client = connect("user=postgres").await;
 

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -352,6 +352,31 @@ async fn command_tag() {
 }
 
 #[tokio::test]
+async fn column_extras() {
+    let client = connect("user=postgres").await;
+
+    let rows: Vec<tokio_postgres::Row> = client
+        .query_raw_txt("select relacl, relname from pg_class limit 1", [])
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+
+    let column = rows[0].columns().get(1).unwrap();
+    assert_eq!(column.name(), "relname");
+    assert_eq!(column.type_(), &Type::NAME);
+
+    assert!(column.table_oid() > 0);
+    assert_eq!(column.column_id(), 2);
+    assert_eq!(column.format(), 0);
+
+    assert_eq!(column.type_oid(), 19);
+    assert_eq!(column.type_size(), 64);
+    assert_eq!(column.type_modifier(), -1);
+}
+
+#[tokio::test]
 async fn custom_composite() {
     let client = connect("user=postgres").await;
 

--- a/tokio-postgres/tests/test/types/chrono_04.rs
+++ b/tokio-postgres/tests/test/types/chrono_04.rs
@@ -1,4 +1,4 @@
-use chrono_04::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono_04::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::fmt;
 use tokio_postgres::types::{Date, FromSqlOwned, Timestamp};
 use tokio_postgres::Client;
@@ -51,12 +51,9 @@ async fn test_with_special_naive_date_time_params() {
 
 #[tokio::test]
 async fn test_date_time_params() {
-    fn make_check(time: &str) -> (Option<DateTime<Utc>>, &str) {
+    fn make_check(time: &str) -> (Option<DateTime<FixedOffset>>, &str) {
         (
-            Some(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
-            ),
+            Some(DateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
             time,
         )
     }
@@ -74,12 +71,9 @@ async fn test_date_time_params() {
 
 #[tokio::test]
 async fn test_with_special_date_time_params() {
-    fn make_check(time: &str) -> (Timestamp<DateTime<Utc>>, &str) {
+    fn make_check(time: &str) -> (Timestamp<DateTime<FixedOffset>>, &str) {
         (
-            Timestamp::Value(
-                Utc.datetime_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'")
-                    .unwrap(),
-            ),
+            Timestamp::Value(DateTime::parse_from_str(time, "'%Y-%m-%d %H:%M:%S.%f'").unwrap()),
             time,
         )
     }


### PR DESCRIPTION
Somebody is preparing with a name still. Let's remove the named statements completely so we don't accidentally use them.