### PR TITLE
Enable transactional pool mode configuration

### DIFF
--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -433,6 +433,20 @@ impl Config {
         self
     }
 
+    /// When enabled, the client skips all internal caching for statements,
+    /// allowing usage with a connection pool with transaction mode.
+    ///
+    /// Defaults to `false`.
+    pub fn transaction_pool_mode(&mut self, enable: bool) -> &mut Config {
+        self.config.transaction_pool_mode(enable);
+        self
+    }
+
+    /// Gets the transaction pool mode status.
+    pub fn get_transaction_pool_mode(&self) -> bool {
+        self.config.get_transaction_pool_mode()
+    }
+
     /// Opens a connection to a PostgreSQL database.
     pub fn connect<T>(&self, tls: T) -> Result<Client, Error>
     where

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -208,6 +208,7 @@ pub struct Config {
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) load_balance_hosts: LoadBalanceHosts,
     pub(crate) max_backend_message_size: Option<usize>,
+    pub(crate) transaction_pool_mode: bool,
 }
 
 impl Default for Config {
@@ -242,6 +243,7 @@ impl Config {
             channel_binding: ChannelBinding::Prefer,
             load_balance_hosts: LoadBalanceHosts::Disable,
             max_backend_message_size: None,
+            transaction_pool_mode: false,
         }
     }
 
@@ -507,6 +509,20 @@ impl Config {
     /// Gets the channel binding behavior.
     pub fn get_channel_binding(&self) -> ChannelBinding {
         self.channel_binding
+    }
+
+    /// When enabled, the client skips all internal caching for statements,
+    /// allowing usage with a connection pool with transaction mode.
+    ///
+    /// Defaults to `false`.
+    pub fn transaction_pool_mode(&mut self, enable: bool) -> &mut Config {
+        self.transaction_pool_mode = enable;
+        self
+    }
+
+    /// Gets the transaction pool mode status.
+    pub fn get_transaction_pool_mode(&self) -> bool {
+        self.transaction_pool_mode
     }
 
     /// Sets the host load balancing behavior.

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -112,7 +112,15 @@ where
     let (process_id, secret_key, parameters) = read_info(&mut stream).await?;
 
     let (sender, receiver) = mpsc::unbounded();
-    let client = Client::new(sender, config.ssl_mode, process_id, secret_key);
+
+    let client = Client::new(
+        sender,
+        config.ssl_mode,
+        process_id,
+        secret_key,
+        config.transaction_pool_mode,
+    );
+
     let connection = Connection::new(stream.inner, stream.delayed, parameters, receiver);
 
     Ok((client, connection))


### PR DESCRIPTION
adds a new config setting `transaction_pool_mode` to disable internal type caches for transactional connection pools