### PR TITLE
tokio-postgres: prepare and execute unnamed statements in one roundtrip

### DIFF
--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -521,15 +521,6 @@ impl Client {
         CancelToken::new(self.client.cancel_token())
     }
 
-    /// Clears the client's type information cache.
-    ///
-    /// When user-defined types are used in a query, the client loads their definitions from the database and caches
-    /// them for the lifetime of the client. If those definitions are changed in the database, this method can be used
-    /// to flush the local cache and allow the new, updated definitions to be loaded.
-    pub fn clear_type_cache(&self) {
-        self.client.clear_type_cache();
-    }
-
     /// Determines if the client's connection has already closed.
     ///
     /// If this returns `true`, the client is no longer usable.

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -4,7 +4,7 @@ use crate::connection::{Request, RequestMessages};
 use crate::copy_out::CopyOutStream;
 #[cfg(feature = "runtime")]
 use crate::keepalive::KeepaliveConfig;
-use crate::query::RowStream;
+use crate::query::{RowStream, };
 use crate::simple_query::SimpleQueryStream;
 #[cfg(feature = "runtime")]
 use crate::tls::MakeTlsConnect;
@@ -326,19 +326,17 @@ impl Client {
 
     /// Pass text directly to the Postgres backend to allow it to sort out typing itself and
     /// to save a roundtrip
-    pub async fn query_raw_txt<'a, T, S, I>(
+    pub async fn query_raw_txt<'a, S, I>(
         &self,
-        statement: &T,
+        query: &str,
         params: I,
     ) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement,
         S: AsRef<str>,
         I: IntoIterator<Item = Option<S>>,
         I::IntoIter: ExactSizeIterator,
     {
-        let statement = statement.__convert().into_statement(self).await?;
-        query::query_txt(&self.inner, statement, params).await
+        query::query_txt(&self.inner, query, params).await
     }
 
     /// Executes a statement, returning the number of rows modified.

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -57,13 +57,12 @@ pub trait GenericClient: private::Sealed {
         I::IntoIter: ExactSizeIterator;
 
     /// Like `Client::query_raw_txt`.
-    async fn query_raw_txt<'a, T, S, I>(
+    async fn query_raw_txt<'a,  S, I>(
         &self,
-        statement: &T,
+        statement: &str,
         params: I,
     ) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send;
@@ -148,9 +147,8 @@ impl GenericClient for Client {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a,  S, I>(&self, statement: &str, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,
@@ -244,9 +242,8 @@ impl GenericClient for Transaction<'_> {
         self.query_raw(statement, params).await
     }
 
-    async fn query_raw_txt<'a, T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    async fn query_raw_txt<'a,  S, I>(&self, statement: &str, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement + Sync + Send,
         S: AsRef<str> + Sync + Send,
         I: IntoIterator<Item = Option<S>> + Sync + Send,
         I::IntoIter: ExactSizeIterator + Sync + Send,

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -47,7 +47,7 @@ pub async fn prepare(
     let mut parameters = vec![];
     let mut it = parameter_description.parameters();
     while let Some(oid) = it.next().map_err(Error::parse)? {
-        let type_ = get_type(client, oid).await?;
+        let type_ = get_type(client, oid);
         parameters.push(type_);
     }
 
@@ -55,7 +55,7 @@ pub async fn prepare(
     if let Some(row_description) = row_description {
         let mut it = row_description.fields();
         while let Some(field) = it.next().map_err(Error::parse)? {
-            let type_ = get_type(client, field.type_oid()).await?;
+            let type_ = get_type(client, field.type_oid());
             let column = Column::new(field.name().to_string(), type_, field);
             columns.push(column);
         }
@@ -68,7 +68,7 @@ pub async fn prepare(
     }
 }
 
-fn encode(client: &InnerClient, name: &str, query: &str, types: &[Type]) -> Result<Bytes, Error> {
+pub(crate) fn encode(client: &InnerClient, name: &str, query: &str, types: &[Type]) -> Result<Bytes, Error> {
     if types.is_empty() {
         debug!("preparing query {}: {}", name, query);
     } else {
@@ -83,14 +83,14 @@ fn encode(client: &InnerClient, name: &str, query: &str, types: &[Type]) -> Resu
     })
 }
 
-pub async fn get_type(client: &Arc<InnerClient>, oid: Oid) -> Result<Type, Error> {
+pub fn get_type(client: &InnerClient, oid: Oid) -> Type {
     if let Some(type_) = Type::from_oid(oid) {
-        return Ok(type_);
+        return type_;
     }
 
-    if let Some(type_) = client.type_(oid) {
-        return Ok(type_);
-    }
+    // if let Some(type_) = client.type_(oid) {
+    //     return Ok(type_);
+    // }
 
-    Ok(Type::TEXT)
+    Type::TEXT
 }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -2,14 +2,15 @@ use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::types::{BorrowToSql, IsNull};
-use crate::{Error, Portal, Row, Statement};
+use crate::{Error, Portal, Row, Statement, Column};
 use bytes::{BufMut, Bytes, BytesMut};
+use fallible_iterator::FallibleIterator;
 use futures_util::{ready, Stream};
 use log::{debug, log_enabled, Level};
 use pin_project_lite::pin_project;
-use postgres_protocol::message::backend::{CommandCompleteBody, Message};
+use postgres_protocol::message::backend::{CommandCompleteBody, Message, ParameterDescriptionBody, RowDescriptionBody};
 use postgres_protocol::message::frontend;
-use postgres_types::Format;
+use postgres_types::{Format, Type};
 use std::fmt;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
@@ -50,7 +51,7 @@ where
     } else {
         encode(client, &statement, params)?
     };
-    let responses = start(client, buf).await?;
+    let (statement, responses) = start(client, buf).await?;
     Ok(RowStream {
         statement,
         responses,
@@ -58,13 +59,14 @@ where
         command_tag: None,
         status: None,
         output_format: Format::Binary,
+        parameter_description: None,
         _p: PhantomPinned,
     })
 }
 
 pub async fn query_txt<S, I>(
     client: &Arc<InnerClient>,
-    statement: Statement,
+    query: &str,
     params: I,
 ) -> Result<RowStream, Error>
 where
@@ -72,13 +74,19 @@ where
     I: IntoIterator<Item = Option<S>>,
     I::IntoIter: ExactSizeIterator,
 {
+    dbg!("here");
     let params = params.into_iter();
 
     let buf = client.with_buf(|buf| {
+        // prepare
+        frontend::parse("", query, std::iter::empty(), buf).map_err(Error::encode)?;
+        frontend::describe(b'S', "", buf).map_err(Error::encode)?;
+        frontend::flush(buf);
+
         // Bind, pass params as text, retrieve as binary
         match frontend::bind(
             "",                 // empty string selects the unnamed portal
-            statement.name(),   // named prepared statement
+            "",   // unnamed prepared statement
             std::iter::empty(), // all parameters use the default format (text)
             params,
             |param, buf| match param {
@@ -104,10 +112,13 @@ where
         Ok(buf.split().freeze())
     })?;
 
+    dbg!("here");
     // now read the responses
-    let responses = start(client, buf).await?;
+    let (statement, responses) = start(client, buf).await?;
+    dbg!("here");
 
     Ok(RowStream {
+        parameter_description: None,
         statement,
         responses,
         command_tag: None,
@@ -132,7 +143,8 @@ pub async fn query_portal(
     let responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
 
     Ok(RowStream {
-        statement: portal.statement().clone(),
+        parameter_description: None,
+        statement: Some(portal.statement().clone()),
         responses,
         rows_affected: None,
         command_tag: None,
@@ -176,7 +188,7 @@ where
     } else {
         encode(client, &statement, params)?
     };
-    let mut responses = start(client, buf).await?;
+    let (_statement, mut responses) = start(client, buf).await?;
 
     let mut rows = 0;
     loop {
@@ -192,19 +204,49 @@ where
     }
 }
 
-async fn start(client: &InnerClient, buf: Bytes) -> Result<Responses, Error> {
+async fn start(client: &InnerClient, buf: Bytes) -> Result<(Option<Statement>, Responses), Error> {
+    let mut parameter_description: Option<ParameterDescriptionBody> = None;
+    let mut statement = None;
     let mut responses = client.send(RequestMessages::Single(FrontendMessage::Raw(buf)))?;
+        let make_statement = |parameter_description: ParameterDescriptionBody, row_description: Option<RowDescriptionBody>| {
+            let mut parameters = vec![];
+            let mut it = parameter_description.parameters();
+            while let Some(oid) = it.next().map_err(Error::parse).unwrap() {
+                let type_ = crate::prepare::get_type(client, oid);
+                parameters.push(type_);
+            }
 
-    match responses.next().await? {
-        Message::ParseComplete => match responses.next().await? {
-            Message::BindComplete => {}
-            m => return Err(Error::unexpected_message(m)),
-        },
-        Message::BindComplete => {}
-        m => return Err(Error::unexpected_message(m)),
-    }
+            let mut columns = vec![];
+            if let Some(row_description) = row_description {
+                let mut it = row_description.fields();
+                while let Some(field) = it.next().map_err(Error::parse).unwrap() {
+                    let type_ = crate::prepare::get_type(client, field.type_oid());
+                    let column = Column::new(field.name().to_string(), type_, field);
+                    columns.push(column);
+                }
+            }
 
-    Ok(responses)
+                Statement::unnamed("Dose this matter?".to_owned(), parameters, columns)
+
+        };
+
+        loop {
+            match responses.next().await? {
+                Message::ParseComplete => {},
+                Message::BindComplete => {return Ok((statement, responses))}
+                Message::ParameterDescription(body) => {
+                    parameter_description = Some(body); // to love me
+                }
+                Message::NoData => {
+                    statement = Some(make_statement(parameter_description.take().unwrap(), None));
+                }
+                Message::RowDescription(body) => {
+                    statement = Some(make_statement(parameter_description.take().unwrap(), Some(body)));
+                }
+                m => return Err(Error::unexpected_message(m)),
+            }
+        }
+
 }
 
 pub fn encode<P, I>(client: &InnerClient, statement: &Statement, params: I) -> Result<Bytes, Error>
@@ -276,12 +318,14 @@ where
 pin_project! {
     /// A stream of table rows.
     pub struct RowStream {
-        statement: Statement,
+        statement: Option<Statement>,
         responses: Responses,
         rows_affected: Option<u64>,
         command_tag: Option<String>,
         output_format: Format,
         status: Option<u8>,
+        parameter_description: Option<ParameterDescriptionBody>,
+
         #[pin]
         _p: PhantomPinned,
     }
@@ -291,12 +335,44 @@ impl Stream for RowStream {
     type Item = Result<Row, Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // dbg!("here");
         let this = self.project();
+        // let make_statement = |parameter_description: ParameterDescriptionBody, row_description: Option<RowDescriptionBody>| {
+        //     let mut parameters = vec![];
+        //     let mut it = parameter_description.parameters();
+        //     while let Some(oid) = it.next().map_err(Error::parse).unwrap() {
+        //         let type_ = Type::TEXT;
+        //         parameters.push(type_);
+        //     }
+
+        //     let mut columns = vec![];
+        //     if let Some(row_description) = row_description {
+        //         let mut it = row_description.fields();
+        //         while let Some(field) = it.next().map_err(Error::parse).unwrap() {
+        //             let type_ = crate::prepare::get_type(client, field.type_oid());
+        //             let column = Column::new(field.name().to_string(), type_, field);
+        //             columns.push(column);
+        //         }
+        //     }
+
+        //         Statement::unnamed("Dose this matter?".to_owned(), parameters, columns)
+
+        // };
         loop {
             match ready!(this.responses.poll_next(cx)?) {
+                // Message::ParseComplete => {} // nice
+                // Message::ParameterDescription(body) => {
+                //     *this.parameter_description = Some(body); // to love me
+                // }
+                // Message::NoData => {
+                //     *this.statement = Some(make_statement(this.parameter_description.take().unwrap(), None));
+                // }
+                // Message::RowDescription(body) => {
+                //     *this.statement = Some(make_statement(this.parameter_description.take().unwrap(), Some(body)));
+                // }
                 Message::DataRow(body) => {
                     return Poll::Ready(Some(Ok(Row::new(
-                        this.statement.clone(),
+                        this.statement.as_ref().unwrap().clone(),
                         body,
                         *this.output_format,
                     )?)))
@@ -341,3 +417,4 @@ impl RowStream {
         self.status
     }
 }
+

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -14,7 +14,6 @@ use std::{
 #[derive(Debug)]
 enum StatementInner {
     Unnamed {
-        query: String,
         params: Vec<Type>,
         columns: Vec<Column>,
     },
@@ -62,25 +61,14 @@ impl Statement {
         }))
     }
 
-    pub(crate) fn unnamed(query: String, params: Vec<Type>, columns: Vec<Column>) -> Self {
-        Statement(Arc::new(StatementInner::Unnamed {
-            query,
-            params,
-            columns,
-        }))
+    pub(crate) fn unnamed(params: Vec<Type>, columns: Vec<Column>) -> Self {
+        Statement(Arc::new(StatementInner::Unnamed { params, columns }))
     }
 
     pub(crate) fn name(&self) -> &str {
         match &*self.0 {
             StatementInner::Unnamed { .. } => "",
             StatementInner::Named { name, .. } => name,
-        }
-    }
-
-    pub(crate) fn query(&self) -> Option<&str> {
-        match &*self.0 {
-            StatementInner::Unnamed { query, .. } => Some(query),
-            StatementInner::Named { .. } => None,
         }
     }
 

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -150,14 +150,13 @@ impl<'a> Transaction<'a> {
     }
 
     /// Like `Client::query_raw_txt`.
-    pub async fn query_raw_txt<T, S, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
+    pub async fn query_raw_txt< S, I>(&self, query: &str, params: I) -> Result<RowStream, Error>
     where
-        T: ?Sized + ToStatement,
         S: AsRef<str>,
         I: IntoIterator<Item = Option<S>>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.client.query_raw_txt(statement, params).await
+        self.client.query_raw_txt(query, params).await
     }
 
     /// Like `Client::execute`.


### PR DESCRIPTION
@tomhoule and @pimeys paired this together today. This solves issues of random `unnamed statement does not exist` errors. They happen sometimes, but pretty often, especially if the roundtrip to the database is longer than localhost.

We remove pipelining completely from the query preparation, making this work to only be useful in a context of unnamed statements and text mode queries.

What used to be: `PARSE`, `DESCRIBE`, `SYNC` and load the response, then `BIND` and load the response is now: `PARSE`, `DESCRIBE`, `FLUSH`, `BIND` and then load the response. We skip one roundtrip, but by referring the Postgres manual, we know that an unnamed statement after a `PARSE` should not receive `SYNC` before loading the data, or the `BIND` might result in the error given above.

Eventually we remove a lot of stuff from this crate, maybe creating our own library while going. For now, it is recommended to not use anything else but the `_txt` methods in the client. Otherwise the sky can fall into your head.