### PR TITLE
Close after sync on txt query

### DIFF
--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -110,6 +110,9 @@ where
         // Sync
         frontend::sync(buf);
 
+        // Close
+        frontend::close(b'S', "", buf).map_err(Error::encode)?;
+
         Ok(buf.split().freeze())
     })?;
 
@@ -210,7 +213,7 @@ async fn start(client: &InnerClient, buf: Bytes) -> Result<(Option<Statement>, R
 
     loop {
         match responses.next().await? {
-            Message::ParseComplete => {}
+            Message::CloseComplete | Message::ParseComplete => {}
             Message::BindComplete => return Ok((statement, responses)),
             Message::ParameterDescription(body) => {
                 parameter_description = Some(body); // tooo-o-ooo-o loooove

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -82,7 +82,6 @@ where
         // prepare
         frontend::parse("", query, std::iter::empty(), buf).map_err(Error::encode)?;
         frontend::describe(b'S', "", buf).map_err(Error::encode)?;
-        frontend::flush(buf);
 
         // Bind, pass params as text, retrieve as binary
         match frontend::bind(

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -56,6 +56,7 @@ pub async fn batch_execute(client: &InnerClient, query: &str) -> Result<(), Erro
             Message::ReadyForQuery(_) => return Ok(()),
             Message::CommandComplete(_)
             | Message::EmptyQueryResponse
+            | Message::CloseComplete
             | Message::RowDescription(_)
             | Message::DataRow(_) => {}
             m => return Err(Error::unexpected_message(m)),


### PR DESCRIPTION
We know node pg works with hyperdrive. What they do and we don't is they send a close message after syncing. Let's try that.

https://github.com/brianc/node-postgres/blob/master/packages/pg-protocol/src/serializer.ts#L264

This works with schema-registry tests muy bueno.