### PR TITLE
 fix: make the order of commands the same as with node-pg 

### DIFF
--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -56,7 +56,6 @@ pub async fn batch_execute(client: &InnerClient, query: &str) -> Result<(), Erro
             Message::ReadyForQuery(_) => return Ok(()),
             Message::CommandComplete(_)
             | Message::EmptyQueryResponse
-            | Message::CloseComplete
             | Message::RowDescription(_)
             | Message::DataRow(_) => {}
             m => return Err(Error::unexpected_message(m)),


### PR DESCRIPTION
![2023-11-16_17-11-1700153667](https://github.com/grafbase/rust-postgres/assets/34967/0f921142-1c84-484a-bffb-e6bda7fab61a)

So, wireshark has been super helpful today, here's what I found out (see the image):

The first 16 packets are from node-pg library, which is guaranteed to work perfectly with HyperDrive. The next four packets are from our fork of tokio-postgres, the version that runs right now in production. The last four packets are from my fixed version of tokio-postgres. We see here, how there is our login to postgres, the first `>`, then a normal series of packets back `<R/S/S/S/S/S/S/S/S/S/S/S.../K/Z`. After that node-postgres sends packets in this order, in separate packages:

- `P` (Parse)
- `B` (Bind)
- `D` (Describe)
- `E` (Execute)
- `S` (Flush)

Now, what we send is `P/D/B/E/S`, we can see that describe and bind are in the wrong order, and we also send the whole series in one package (which should be possible per docs, and faster).

This PR changes the order of describe and bind, so we bind first and describe right after that. It also removes matches of `CloseComplete` from two spots, which were added when we explicitly closed after the flush.

The next step is to test this with the script from @tomhoule, and if it succeeds, then we deploy to production and _pray_.